### PR TITLE
Enabled dark and light mode with switch for docs using docsify-darklight-theme

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -3,7 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <title>Documentation · vue2-datatable-component</title>
-  <link href="//unpkg.com/docsify/themes/vue.css" rel="stylesheet">
+  <link 
+    rel="stylesheet"
+    href="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/style.min.css"
+    title="docsify-darklight-theme"
+    type="text/css"
+  />
   <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
 </head>
 <body>
@@ -30,6 +35,10 @@
       '/zh-cn/.*/_sidebar.md': '/zh-cn/_sidebar.md'
     }
   }
+</script>
+<script 
+    src="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/index.min.js"
+    type="text/javascript">
 </script>
 <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
 </body>


### PR DESCRIPTION
Enabled dark and light mode with switch for docs using docsify-darklight-theme with redesigned search bar. For more customization [see here](https://boopathikumar018.github.io/docsify-darklight-theme)

**Light Mode :**

Before 

![image](https://user-images.githubusercontent.com/10001746/79608306-63ae8e80-8112-11ea-9c9d-487a07d794ef.png)

After

![image](https://user-images.githubusercontent.com/10001746/79608344-7628c800-8112-11ea-9146-724f02873480.png)

**Dark Mode :**

![image](https://user-images.githubusercontent.com/10001746/79608393-8b9df200-8112-11ea-90a2-d19bfe390825.png)


